### PR TITLE
remove both global variables

### DIFF
--- a/distest/__init__.py
+++ b/distest/__init__.py
@@ -5,7 +5,7 @@
 """
 
 import argparse
-from sys import exit
+import sys
 
 import discord
 
@@ -362,4 +362,4 @@ def run_command_line_bot(target, token, tests, channel_id, stats, collector, tim
     """
     bot = DiscordCliInterface(target, collector, tests, channel_id, stats, timeout)
     failed = bot.run(token)  # returns True if a test failed
-    exit(1 if failed else 0)
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
In this PR I have removed all instances of all global variables (EXIT_CODE and TIMEOUT). I have replaced EXIT_CODE by adding an instance variable called ``failure`` to ``DiscordCliInterface`` that is used to track whether or not a test has failed. I have also overridden the default ``run`` function to return the state of the ``failure`` variable, allowing the program to exit 1 or 0 depending on what's appropriate.

I handled TIMEOUT similarly, adding an instance variable ``timeout`` to ``DiscordInteractiveInterface`` (and therefore ``DiscordCliInterface`` since the latter inherits the former) that defaults to 5. You will notice new parameters in the run functions ``run_dtest_bot``, ``run_command_line_bot``, and ``run_interactive_bot`` to allow outside control of the timeout variable without modifying our code.

This change will benefit us in the long run as global variables are notoriously difficult to maintain, and it breaks a lot of programming design "rules" (inherent tight coupling, single responsibility principle, Open-closed principle, probably a few more)

